### PR TITLE
use good syntax in the minify command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "jest --coverage --no-cache",
     "build": "npm run bundle && npm run minify",
     "bundle": "rollup -i src/index.js -o dist/effects.js -m -f umd -n effects",
-    "minify": "uglifyjs dist/effects.js -o dist/effects.js -mc pure_funcs=Object.defineProperty --source-map includeSources,url=effects.js.map",
+    "minify": "uglifyjs dist/effects.js -o dist/effects.js -mc pure_funcs=['Object.defineProperty'] --source-map includeSources,url=effects.js.map",
     "prepare": "npm run build",
     "format": "prettier --semi false --write '{src,test}/**/*.js'"
   },


### PR DESCRIPTION
The correct compress options are described here:
 - https://github.com/mishoo/UglifyJS2#compress-options

Still don't understand why we use: `pure_funcs=['Object.defineProperty']`. 
Since `Object.defineProperty` is not a pure function at all. Why want to remove it ?

it removes `Object.defineProperty(__esmodule, {...});` 

https://github.com/HyperappCommunity/hyperapp-effects/pull/21
It looks like uglifyJS don't compile the code well with bad options. 

Maybe we should check if this mistake is done anywhere else ? (in the hyperapp core ??) It could have terrifying side effetcs.